### PR TITLE
make it possible to pass puppeteer launch options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,11 +12,22 @@ InvalidUrlError.prototype = Error.prototype
 /**
  * @param {string} url URL to get CSS from
  * @param {string} waitUntil https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagegotourl-options
+ * @param {Object} launchOptions https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#puppeteerlaunchoptions
  * @returns {string} All CSS that was found
  */
-module.exports = async (url, {waitUntil = 'networkidle0', origins = 'exclude'} = {}) => {
+module.exports = async (
+	url, 
+	{ 
+		waitUntil = 'networkidle0',
+		origins = 'exclude', 
+		launchOptions = { 
+			headless: true,
+			args: [],
+		}
+	} = {}
+	) => {
 	// Setup a browser instance
-	const browser = await puppeteer.launch()
+	const browser = await puppeteer.launch(launchOptions)
 
 	// Create a new page and navigate to it
 	const page = await browser.newPage()

--- a/src/index.js
+++ b/src/index.js
@@ -16,16 +16,16 @@ InvalidUrlError.prototype = Error.prototype
  * @returns {string} All CSS that was found
  */
 module.exports = async (
-	url, 
-	{ 
+	url,
+	{
 		waitUntil = 'networkidle0',
-		origins = 'exclude', 
-		launchOptions = { 
+		origins = 'exclude',
+		launchOptions = {
 			headless: true,
-			args: [],
+			args: []
 		}
 	} = {}
-	) => {
+) => {
 	// Setup a browser instance
 	const browser = await puppeteer.launch(launchOptions)
 


### PR DESCRIPTION
This PR adds the possibility to pass puppeteer launch options, as it is necessary to solve deploy problems like [this one](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-on-heroku) for example

All the possible options can be seen here
https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#puppeteerlaunchoptions

(Thanks for the lib, it is really helpful)